### PR TITLE
アイコンをチャットマークに変え、ドラッグのみならずタップでも遷移できるように

### DIFF
--- a/lib/ui/screens/ai_screen/home_screen.dart
+++ b/lib/ui/screens/ai_screen/home_screen.dart
@@ -3,16 +3,6 @@ import 'package:aitrip/ui/screens/ai_screen/voice_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/* class HoverStateNotifier extends StateNotifier<bool> {
-  HoverStateNotifier() : super(false);
-
-  void setHover(bool isHovering) => state = isHovering;
-}
-
-// StateNotifierProvider を定義
-final hoverProvider = StateNotifierProvider<HoverStateNotifier, bool>(
-  (ref) => HoverStateNotifier(),
-); */
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -71,8 +61,6 @@ class HomeScreen extends ConsumerWidget {
       handleDragEnd(context);
     }
 
-    //final isHovering = ref.watch(hoverProvider);
-
     return Scaffold(
       key: scaffoldKey,
       appBar: AppBar(
@@ -94,13 +82,6 @@ class HomeScreen extends ConsumerWidget {
         actions: <Widget>[
           Padding(
             padding: const EdgeInsets.only(right: 40.0),
-            /* child: MouseRegion(
-              onEnter: (_) {
-                ref.read(hoverProvider.notifier).setHover(true);
-              },
-              onExit: (_) {
-                ref.read(hoverProvider.notifier).setHover(false);
-              }, */
             child: GestureDetector(
               onTap: (){
                 simulateVerticalDrag(context);  // ドラッグと同じ処理をするため、ここでドラッグを模擬
@@ -114,7 +95,7 @@ class HomeScreen extends ConsumerWidget {
                 handleDragEnd(context);
               },
               child: Icon(
-                Icons.chat,
+                Icons.comment_rounded,
                 color/* : isHovering
                       ? Theme.of(context)
                           .colorScheme
@@ -124,7 +105,6 @@ class HomeScreen extends ConsumerWidget {
               ),
             ),
           ),
-          //)
         ],
       ),
       body: const VoiceScreen(),

--- a/lib/ui/screens/ai_screen/home_screen.dart
+++ b/lib/ui/screens/ai_screen/home_screen.dart
@@ -3,6 +3,17 @@ import 'package:aitrip/ui/screens/ai_screen/voice_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+/* class HoverStateNotifier extends StateNotifier<bool> {
+  HoverStateNotifier() : super(false);
+
+  void setHover(bool isHovering) => state = isHovering;
+}
+
+// StateNotifierProvider を定義
+final hoverProvider = StateNotifierProvider<HoverStateNotifier, bool>(
+  (ref) => HoverStateNotifier(),
+); */
+
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
@@ -40,6 +51,28 @@ class HomeScreen extends ConsumerWidget {
       overlayEntry?.markNeedsBuild();
     }
 
+    void handleDragEnd(BuildContext context) { //ドラッグ時に遷移を行う関数、二重遷移を防ぐ。
+      if (opacity > 0.5) {
+        Navigator.push(
+          context,
+        MaterialPageRoute(
+          builder: (context) => ChatScreen(
+              showAppBar: true,
+            ),
+          ),
+        );
+      }
+      hideOverlay();
+    }
+
+    void simulateVerticalDrag(BuildContext context) {
+      showOverlay(context);
+      updateOpacity(1.0);  // 完全にドラッグされた状態を模擬
+      handleDragEnd(context);
+    }
+
+    //final isHovering = ref.watch(hoverProvider);
+
     return Scaffold(
       key: scaffoldKey,
       appBar: AppBar(
@@ -61,32 +94,37 @@ class HomeScreen extends ConsumerWidget {
         actions: <Widget>[
           Padding(
             padding: const EdgeInsets.only(right: 40.0),
+            /* child: MouseRegion(
+              onEnter: (_) {
+                ref.read(hoverProvider.notifier).setHover(true);
+              },
+              onExit: (_) {
+                ref.read(hoverProvider.notifier).setHover(false);
+              }, */
             child: GestureDetector(
+              onTap: (){
+                simulateVerticalDrag(context);  // ドラッグと同じ処理をするため、ここでドラッグを模擬
+              },
               onVerticalDragUpdate: (details) {
                 double delta = (details.primaryDelta ?? 0.0) / 100;
                 showOverlay(context);
                 updateOpacity(delta);
               },
               onVerticalDragEnd: (details) {
-                if (opacity > 0.5) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => ChatScreen(
-                              showAppBar: true,
-                            )),
-                  );
-                  hideOverlay();
-                } else {
-                  hideOverlay();
-                }
+                handleDragEnd(context);
               },
               child: Icon(
-                Icons.schedule_rounded,
-                color: Theme.of(context).colorScheme.onPrimaryContainer,
+                Icons.chat,
+                color/* : isHovering
+                      ? Theme.of(context)
+                          .colorScheme
+                          .onPrimaryContainer
+                          .withOpacity(0.7) */
+                      : Theme.of(context).colorScheme.onPrimaryContainer,
               ),
             ),
-          )
+          ),
+          //)
         ],
       ),
       body: const VoiceScreen(),


### PR DESCRIPTION
 Close #105 
- アイコンの変更
- ドラッグのみならずタップでも遷移できるように
- 二重遷移しないための工夫

? ホバー時に他のアイコンと同じようにグレーになるようなアニメーションを加えようとしたけれど遷移の動きに影響が出た（画面が重なって表示されるようになった）ので止めました。ホバー時のアニメーションも加えた方が良いかな？ 